### PR TITLE
Fix link to usage examples

### DIFF
--- a/lexutils/config/config.example.py
+++ b/lexutils/config/config.example.py
@@ -13,6 +13,7 @@ wd_prefix = "http://www.wikidata.org/entity/"
 user_agent = f"LexUtils/{version}"
 
 # Settings for UsageExamples
+require_form_confirmation = True
 fast_nlp_languages = [WikimediaLanguageCode.SWEDISH, WikimediaLanguageCode.ENGLISH]
 add_to_watchlist = True
 number_of_forms_to_fetch = 20

--- a/lexutils/helpers/tui.py
+++ b/lexutils/helpers/tui.py
@@ -50,9 +50,10 @@ def work_on(form: Form = None):
     )
 
 
-def number_of_found_sentences(dict_length):
-    print(_("Found {} suitable sentences".format(
-        dict_length,
+def number_of_found_sentences(number_of_usage_examples: int = None,
+                              form: Form = None):
+    print(_("Found {} suitable sentences for {} with id {}".format(
+        number_of_usage_examples, form.representation, form.id
     )))
 
 

--- a/lexutils/models/wikidata/entities.py
+++ b/lexutils/models/wikidata/entities.py
@@ -87,6 +87,9 @@ class Lexeme:
     def url(self):
         return f"{config.wd_prefix}{self.id}"
 
+    def usage_example_url(self):
+        return f"https://www.wikidata.org/wiki/Lexeme:{self.id}#P5831"
+
     # def upload_foreign_id_to_wikidata(self,
     #                                   foreign_id: ForeignID = None):
     #     """Upload to enrich the wonderful Wikidata <3"""

--- a/lexutils/models/wikisource.py
+++ b/lexutils/models/wikisource.py
@@ -1,4 +1,5 @@
 import logging
+from html import unescape
 from typing import List
 from urllib.parse import quote
 
@@ -32,7 +33,8 @@ class WikisourceRecord(Record):
         except KeyError:
             raise KeyError("Could not find title")
         try:
-            self.text = json["snippet"]["value"]
+            # Remove &quot; and the like from the snippet
+            self.text = unescape(json["snippet"]["value"])
         except KeyError:
             raise KeyError("Could not find snippet")
         self.language_code = lexemelanguage.language_code

--- a/lexutils/modules/usage_examples.py
+++ b/lexutils/modules/usage_examples.py
@@ -300,7 +300,7 @@ def process_result(
         # Fetch sentence data from all APIs
         examples: List[UsageExample] = get_usage_examples_from_apis(form, language)
         number_of_examples = len(examples)
-        tui.number_of_found_sentences(number_of_examples)
+        tui.number_of_found_sentences(number_of_examples, form=form)
         if number_of_examples == 0:
             print_separator()
         elif number_of_examples > 0:

--- a/lexutils/modules/usage_examples.py
+++ b/lexutils/modules/usage_examples.py
@@ -183,7 +183,7 @@ def choose_sense_handler(
     #     senses=senses,
     #     form=form
     # )
-    if isinstance(sense_choice, Sense):
+    if isinstance(sense_choice, Sense):n
         logger.info("We got a sense that was accepted")
         # Prepare
         if isinstance(usage_example.record, RiksdagenRecord):
@@ -199,7 +199,7 @@ def choose_sense_handler(
         if result is not None:
             logger.info(f"wbi:{sense_choice}")
             print("Successfully added usage example " +
-                  f"to {form.url()}")
+                  f"{lexeme.usage_example_url()}")
             if config.add_to_watchlist:
                 add_to_watchlist(form.lexeme_id)
             # logger.info("debug exit")

--- a/lexutils/modules/usage_examples.py
+++ b/lexutils/modules/usage_examples.py
@@ -294,11 +294,9 @@ def process_result(
         form: Form = None,
         language: LexemeLanguage = None
 ):
-    """This loops through each form, gets usage examples and present them to the user one by one.
+    """This handles confirmation working on a form and gets usage examples
     It has only side-effects"""
-    logger = logging.getLogger(__name__)
-    # ask to continue
-    if yes_no_question(tui.work_on(form=form)):
+    def fetch_usage_examples():
         # Fetch sentence data from all APIs
         examples: List[UsageExample] = get_usage_examples_from_apis(form, language)
         number_of_examples = len(examples)
@@ -312,6 +310,14 @@ def process_result(
             )
         else:
             print_separator()
+
+    logger = logging.getLogger(__name__)
+    # ask to continue
+    if config.require_form_confirmation:
+        if yes_no_question(tui.work_on(form=form)):
+            fetch_usage_examples()
+    else:
+        fetch_usage_examples()
 
 
 def process_forms(lexemelanguage: LexemeLanguage = None):


### PR DESCRIPTION
This helps to avoid unneccesary scrolling
Linking direct to the added example would be nice but we don't get the UUID of the added example from WBI and would have to look it up from WD to link to the exact example that was just added.